### PR TITLE
表示崩れの修正

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -30,6 +30,9 @@
       @apply absolute top-0 left-0 w-full h-full;
     }
   }
+  pre {
+    @apply whitespace-pre-wrap bg-gray-100 text-sm p-4 rounded;
+  }
 }
 
 .interview {


### PR DESCRIPTION
# issueへのリンク  
#221  

## やったこと(実装内容)
- `<pre>`タグのはみ出して表示されてしまっていた表示崩れを修正。

## 動作確認(スクショ) 
- 修正前
<img width="1440" alt="スクリーンショット 2023-04-15 9 34 51" src="https://user-images.githubusercontent.com/90499315/232174345-eaf977ba-fb7e-4df4-b4e4-cf2807d5e33d.png">

- 修正後
<img width="1440" alt="スクリーンショット 2023-04-15 9 35 14" src="https://user-images.githubusercontent.com/90499315/232174356-4e60e30b-9963-478c-a0b8-c27760523fe9.png">


## 補足