### PR TITLE
news・hubページにsnsアイコンをのせる

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "13.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-share": "^4.4.1",
     "sass": "^1.57.1",
     "tailwindcss": "^3.2.4"
   },

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,0 +1,26 @@
+import {
+  FacebookIcon,
+  FacebookShareButton,
+  LinkedinIcon,
+  LinkedinShareButton,
+  TwitterIcon,
+  TwitterShareButton,
+} from 'react-share'
+
+const ShareButtons = () => {
+  return (
+    <div className="flex gap-2 my-4 justify-end">
+      <FacebookShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+        <FacebookIcon size={28} round />
+      </FacebookShareButton>
+      <TwitterShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+        <TwitterIcon size={28} round />
+      </TwitterShareButton>
+      <LinkedinShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+        <LinkedinIcon size={28} round />
+      </LinkedinShareButton>
+    </div>
+  )
+}
+
+export { ShareButtons }

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -7,16 +7,21 @@ import {
   TwitterShareButton,
 } from 'react-share'
 
-const ShareButtons = () => {
+type Props = {
+  type: string
+  slug: string
+}
+
+const ShareButtons = ({ type, slug }: Props) => {
   return (
     <div className="flex gap-2 my-4 justify-end">
-      <FacebookShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+      <FacebookShareButton url={`https://anti-pattern.co.jp/${type}/${slug}`}>
         <FacebookIcon size={28} round />
       </FacebookShareButton>
-      <TwitterShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+      <TwitterShareButton url={`https://anti-pattern.co.jp/${type}/${slug}`}>
         <TwitterIcon size={28} round />
       </TwitterShareButton>
-      <LinkedinShareButton url="https://anti-pattern.co.jp/news/climbers2023-startup-japan-expo">
+      <LinkedinShareButton url={`https://anti-pattern.co.jp/${type}/${slug}`}>
         <LinkedinIcon size={28} round />
       </LinkedinShareButton>
     </div>

--- a/src/pages/hub/[uid].tsx
+++ b/src/pages/hub/[uid].tsx
@@ -2,6 +2,7 @@ import { SliceZone } from '@prismicio/react'
 import { BaseLayout } from 'components/BaseLayout'
 import { CustomHead } from 'components/CustomHead'
 import { Tags } from 'components/hub/Tags'
+import { ShareButtons } from 'components/ShareButtons'
 import type { GetStaticPropsContext, InferGetStaticPropsType } from 'next'
 import { components } from 'slices'
 import { getFormattedDate } from 'utils/date'
@@ -43,7 +44,8 @@ export default function Hub({ page }: PageProps) {
           <h2 className="text-xl lg:text-2xl font-bold mb-6 md:mb-8 mt-6">
             {page.data.title}
           </h2>
-          <section className="pt-6 md:pt-12 border-t-4 border-stone-100">
+          <section className="border-t-4 border-stone-100">
+            <ShareButtons type={page.type} slug={page.uid} />
             {page.data.hero_image.url && (
               <img
                 src={page.data.hero_image.url}
@@ -53,6 +55,7 @@ export default function Hub({ page }: PageProps) {
               />
             )}
             <SliceZone slices={page.data.slices} components={components} />
+            <ShareButtons type={page.type} slug={page.uid} />
           </section>
           <p className="flex justify-end gap-2 text-ap-green text-sm font-bold mt-24 md:mt-36">
             <Tags tags={page.tags} />

--- a/src/pages/news/[uid].tsx
+++ b/src/pages/news/[uid].tsx
@@ -48,8 +48,8 @@ export default function News({ page }: PageProps) {
                 />
               )}
               <SliceZone slices={page.data.slices} components={components} />
+              <ShareButtons type={page.type} slug={page.uid} />
             </section>
-            <ShareButtons type={page.type} slug={page.uid} />
           </article>
         </div>
       </BaseLayout>

--- a/src/pages/news/[uid].tsx
+++ b/src/pages/news/[uid].tsx
@@ -38,7 +38,7 @@ export default function News({ page }: PageProps) {
               {page.data.title}
             </h2>
             <section className="border-t-4 border-stone-100">
-              <ShareButtons />
+              <ShareButtons type={page.type} slug={page.uid} />
               {page.data.hero_image.url && (
                 <img
                   src={page.data.hero_image.url}
@@ -49,7 +49,7 @@ export default function News({ page }: PageProps) {
               )}
               <SliceZone slices={page.data.slices} components={components} />
             </section>
-            <ShareButtons />
+            <ShareButtons type={page.type} slug={page.uid} />
           </article>
         </div>
       </BaseLayout>

--- a/src/pages/news/[uid].tsx
+++ b/src/pages/news/[uid].tsx
@@ -1,6 +1,7 @@
 import { SliceZone } from '@prismicio/react'
 import { BaseLayout } from 'components/BaseLayout'
 import { CustomHead } from 'components/CustomHead'
+import { ShareButtons } from 'components/ShareButtons'
 import type { GetStaticPropsContext, InferGetStaticPropsType } from 'next'
 import { components } from 'slices'
 import { getFormattedDate } from 'utils/date'
@@ -36,7 +37,8 @@ export default function News({ page }: PageProps) {
             <h2 className="text-2xl lg:text-4xl font-bold mb-6 md:mb-8 mt-6">
               {page.data.title}
             </h2>
-            <section className="pt-6 md:pt-12 border-t-4 border-stone-100">
+            <section className="border-t-4 border-stone-100">
+              <ShareButtons />
               {page.data.hero_image.url && (
                 <img
                   src={page.data.hero_image.url}
@@ -47,6 +49,7 @@ export default function News({ page }: PageProps) {
               )}
               <SliceZone slices={page.data.slices} components={components} />
             </section>
+            <ShareButtons />
           </article>
         </div>
       </BaseLayout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -2166,7 +2171,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
   integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3878,6 +3883,13 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==
+  dependencies:
+    debug "^2.1.3"
+
 jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -5163,6 +5175,14 @@ react-remove-scroll@2.5.5:
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
+
+react-share@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-4.4.1.tgz#4bfb0b512e26afedfea2fb66eb13c95c28fb216a"
+  integrity sha512-AJ9m9RiJssqvYg7MoJUc9J0D7b/liWrsfQ99ndKc5vJ4oVHHd4Fy87jBlKEQPibT40oYA3AQ/a9/oQY6/yaigw==
+  dependencies:
+    classnames "^2.3.2"
+    jsonp "^0.2.1"
 
 react-style-singleton@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
# issueへのリンク  
#181 

## やったこと(実装内容)
- hubとnewsページにシェア用のSNSアイコンを追加

- アイコンをクリックすると、各SNSで開いているページを共有する画面が表示されることを確認

## 動作確認(スクショ) 
- newsページ(タイトル下と記事最下部に追加されている)
![screencapture-localhost-3000-news-climbers2023-startup-japan-expo-2023-05-14-23_36_32](https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/90499315/a951a04e-7b87-4fd6-8c07-5e27d7229c50)

- hubページ(タイトル下と記事最下部に追加されている)
![screencapture-localhost-3000-hub-b-dash-camp-2022-sapporo-2023-05-14-23_38_33](https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/90499315/008b7372-9cb6-413e-a147-cfee89baab4f)


## 補足
