### PR TITLE
ヘッダーの「ブログ」リンクデザインを微修正

### DIFF
--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -1,4 +1,4 @@
-import BlogLink from 'images/blog-link-icon.png'
+import { Square2StackIcon } from '@heroicons/react/24/outline'
 import Facebook from 'images/fb-w.png'
 import Linkedin from 'images/li-w.png'
 import Twitter from 'images/tw-w.png'
@@ -34,16 +34,13 @@ const Footer = () => {
             href="https://tech.anti-pattern.co.jp/"
             target={'_blank'}
             rel="noreferrer"
+            className="flex items-center gap-1"
           >
             <span className="text-white text-sm">
               {locale === 'ja' ? 'エンジニアブログ' : 'Engineer Blog'}
             </span>
             <span>
-              <Image
-                src={BlogLink}
-                alt="blog"
-                className="w-2 inline ml-1 pb-0.5"
-              />
+              <Square2StackIcon stroke="white" className="w-4 rotate-90" />
             </span>
           </a>
           <div className="flex flex-wrap gap-5 mt-5">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -182,6 +182,11 @@ const Header = () => {
                       <div className="ml-4 text-base font-medium text-gray-900">
                         {resource.name}
                       </div>
+                      {resource.isTargetBlank ? (
+                        <Square2StackIcon className="ml-1 w-4 rotate-90" />
+                      ) : (
+                        ''
+                      )}
                     </Link>
                   ))}
                 </nav>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -175,6 +175,7 @@ const Header = () => {
                       key={resource.name}
                       href={resource.href}
                       className="-m-3 flex items-center rounded-lg p-3 hover:bg-gray-50"
+                      target={resource.isTargetBlank ? '_blank' : ''}
                     >
                       <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md bg-ap-green text-white">
                         <resource.icon className="h-6 w-6" aria-hidden="true" />

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -6,6 +6,7 @@ import {
   DocumentTextIcon,
   GlobeAltIcon,
   NewspaperIcon,
+  Square2StackIcon,
   Squares2X2Icon,
   UserGroupIcon,
   XMarkIcon,
@@ -112,13 +113,18 @@ const Header = () => {
                 href={resource.href}
                 target={resource.isTargetBlank ? '_blank' : ''}
                 className={
-                  'text-base font-medium text-gray-500 hover:text-gray-900 pb-1 ' +
+                  'flex items-center gap-1 text-base font-medium text-gray-500 hover:text-gray-900 pb-1 ' +
                   (isCurrentPage(resource.href)
                     ? 'border-b-2 border-gray-500'
                     : '')
                 }
               >
                 {resource.name}
+                {resource.isTargetBlank ? (
+                  <Square2StackIcon className="w-4 rotate-90" />
+                ) : (
+                  ''
+                )}
               </Link>
             )
           })}


### PR DESCRIPTION
# issueへのリンク  
#270 

## やったこと(実装内容)
- ヘッダーの「ブログ」リンクにアイコンをつけた
- フッターのアイコンをheroiconsに変更した
- ハンバーガーメニューの「ブログ」リンクにアイコンをつけた

## 動作確認(スクショ) 
- ヘッダー
![スクリーンショット 2023-08-15 10 03 52](https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/90499315/04246212-798f-464a-b4dc-4a71a26a4252)

- フッター
![スクリーンショット 2023-08-15 10 04 28](https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/90499315/d660ebbc-0320-4a14-8af1-0094cd9c40e3)

- ハンバーガーメニュー
![スクリーンショット 2023-08-16 9 23 53](https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/90499315/a433cbf9-b3f5-4513-8f54-784ea8ae58e2)

## 補足
フッターのアイコンが従来のサイズだとぼやけて見えたため少し大きくしました