### PR TITLE
ページネーション実装に伴うprismicのプレビュー用のpathを変更

### DIFF
--- a/prismicio.ts
+++ b/prismicio.ts
@@ -13,11 +13,11 @@ export const repositoryName = prismic.getRepositoryName(sm.apiEndpoint)
 const routes = [
   {
     type: 'news',
-    path: '/news',
+    path: '/news/1',
   },
   {
     type: 'news',
-    path: '/news/:uid',
+    path: '/news/post/:uid',
   },
   {
     type: 'legal_policy',
@@ -25,11 +25,11 @@ const routes = [
   },
   {
     type: 'hub',
-    path: '/hub',
+    path: '/hub/1',
   },
   {
     type: 'hub',
-    path: '/hub/:uid',
+    path: '/hub/post/:uid',
   },
   {
     type: 'job_position',


### PR DESCRIPTION
# issueへのリンク  
#265 

## やったこと(実装内容)
- prismic記事の未確定情報や日時の文言を最新化した。
- prismicプレビューを正しいパスで見られるように修正した。
  - 動作確認のためprismicのプレビュー設定に`Feature265`を追加したので、プレビューを試す場合は`Production`
ではなく`Feature265`を使ってください。
## 動作確認(スクショ) 

## 補足
