### PR TITLE
会社概要から労働者派遣と職業紹介を削除

### DIFF
--- a/src/components/company/Outline.tsx
+++ b/src/components/company/Outline.tsx
@@ -20,13 +20,13 @@ const outline1: ReadonlyArray<OutlineContent> = [
     title: '所在地',
     content: '東京都港区南⻘山3-15-9 MINOWA表参道3階',
   },
+]
+
+const outline2: ReadonlyArray<OutlineContent> = [
   {
     title: '代表番号',
     content: '03-6885-6136',
   },
-]
-
-const outline2: ReadonlyArray<OutlineContent> = [
   {
     title: '社員数',
     content: '46名 (2023年4月1日時点)',

--- a/src/components/company/Outline.tsx
+++ b/src/components/company/Outline.tsx
@@ -39,14 +39,6 @@ const outline2: ReadonlyArray<OutlineContent> = [
     title: '主要株主',
     content: '小笹佑京',
   },
-  {
-    title: '労働者派遣',
-    content: '派13-314618',
-  },
-  {
-    title: '職業紹介',
-    content: '13-ユ-311813',
-  },
 ]
 
 type Props = {


### PR DESCRIPTION
# やったこと
- 会社概要から労働者派遣と職業紹介を削除
- 会社概要の段組を整頓

# 関連するissue
#282 

# screenshot
<img width="1440" alt="スクリーンショット 2024-03-08 16 33 00" src="https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/a191f7b4-8b27-40a5-b893-f86455397133">
