### PR TITLE
ISO270001の表示変更

### DIFF
--- a/src/pages/company/index.tsx
+++ b/src/pages/company/index.tsx
@@ -35,11 +35,14 @@ const Company = () => {
                 alt="aws Partner Select Tier Services"
                 className="h-32 w-auto"
               />
-              <Image
-                src={ISMS}
-                alt="ISOIEC 27001 Information Security Management System Certification"
-                className="h-32 w-auto"
-              />
+              <div>
+                <Image
+                  src={ISMS}
+                  alt="ISOIEC 27001 Information Security Management System Certification"
+                  className="h-32 w-auto"
+                />
+                <p className="text-center">IS 794005</p>
+              </div>
             </div>
           </section>
         </div>


### PR DESCRIPTION
## What's Changed

- ISMSのロゴ配下にIS 794005という認証番号を追加
- 文字サイズは他のフォントサイズと合わせてください
-

## What's Required Of Reviewer

-
-

## Linked Issues

- #737 
-

## Screenshots
### PC画面
<img width="496" alt="スクリーンショット 2024-04-16 17 07 56" src="https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/053c9d34-57fc-4f7f-906c-4048b97b8839">

### SP画面
<img width="283" alt="スクリーンショット 2024-04-16 17 08 22" src="https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/c476795b-2457-424d-9188-c54841e11441">