### PR TITLE
NEWSページの一覧表示の不具合を修正

### DIFF
--- a/src/pages/news/[page].tsx
+++ b/src/pages/news/[page].tsx
@@ -79,6 +79,7 @@ export async function getStaticProps({
   const pages = await client.get({
     predicates: [prismic.predicate.at('document.type', 'news')],
     page: page,
+    orderings: ['my.news.publication_date desc'],
     pageSize: pageSize,
   })
 


### PR DESCRIPTION
## What's Changed
- NEWSの表示順が指定されておらず、1ページ目に2024〜2020年のデータがあるにも関わらず2ページ目には2023〜2020年分のニュースのデータが表示されていたりと不具合が生じていたため、「published_date」で表示順を降順に指定

### 変更前の状態
https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/dc02463a-488f-42fe-b234-b4e86788cea0

## Linked Issues
- #294 

## Screenshots
https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/934d95a7-d60d-4782-a749-40f6e605b814
