### PR TITLE
Hubの表示順を作成日順になるように設定

### DIFF
--- a/src/pages/hub/[page].tsx
+++ b/src/pages/hub/[page].tsx
@@ -113,6 +113,7 @@ export async function getStaticProps({
   const pages = await client.get({
     predicates: [prismic.predicate.at('document.type', 'hub')],
     page: page,
+    orderings: ['my.hub.publication_date desc'],
     pageSize: pageSize,
   })
 
@@ -130,7 +131,7 @@ export async function getStaticPaths() {
 
   const response = await client.get({
     predicates: [prismic.predicate.at('document.type', 'hub')],
-    orderings: ['my.hub.publication_date desc'],
+    orderings: ['my.hub.last_updated_date desc'],
     pageSize: 1,
   })
 


### PR DESCRIPTION
## 行った変更
prismicからデータ取得時に作成日順にする設定を明記した

## 変更した理由
現時点では作成日順に並んでいるが、Newページと同様に作成日順に並ぶような記述なく、最終編集日順になっているため潜在的に順番が変わってくる可能性が考えられたため