### PR TITLE
英語版ページを非表示

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,20 @@ const nextConfig = {
       },
     ]
   },
+  async redirects() {
+    return [
+      {
+        source: '/en',
+        destination: '/',
+        permanent: false,
+      },
+      {
+        source: '/en/:path*',
+        destination: '/:path*',
+        permanent: false,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const path = require('path')
 const nextConfig = {
   reactStrictMode: true,
   i18n: {
-    locales: ['ja'],
+    locales: ['ja'], // 英語化対応時にlocaleの設定を以下に戻す
     // locales: ['en', 'ja'],
     defaultLocale: 'ja',
   },

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,8 @@ const path = require('path')
 const nextConfig = {
   reactStrictMode: true,
   i18n: {
-    locales: ['en', 'ja'],
+    locales: ['ja'],
+    // locales: ['en', 'ja'],
     defaultLocale: 'ja',
   },
   pageExtensions: ['tsx', 'ts', 'jsx', 'js'],

--- a/src/pages/hub/post/[uid].tsx
+++ b/src/pages/hub/post/[uid].tsx
@@ -99,6 +99,7 @@ export const getStaticPaths = async () => {
   }
   const paths: Path[] = []
   pages.forEach((page) => {
+    // localeに"en"を追加する場合は以下のコメントアウトを外す
     // paths.push({
     //   params: {
     //     uid: page.uid,

--- a/src/pages/hub/post/[uid].tsx
+++ b/src/pages/hub/post/[uid].tsx
@@ -99,12 +99,12 @@ export const getStaticPaths = async () => {
   }
   const paths: Path[] = []
   pages.forEach((page) => {
-    paths.push({
-      params: {
-        uid: page.uid,
-      },
-      locale: 'en',
-    })
+    // paths.push({
+    //   params: {
+    //     uid: page.uid,
+    //   },
+    //   locale: 'en',
+    // })
     paths.push({
       params: {
         uid: page.uid,

--- a/src/pages/news/post/[uid].tsx
+++ b/src/pages/news/post/[uid].tsx
@@ -90,6 +90,7 @@ export const getStaticPaths = async () => {
   }
   const paths: Array<Path> = []
   pages.forEach((page) => {
+    // localeに"en"を追加する場合は以下のコメントアウトを外す
     // paths.push({
     //   params: {
     //     uid: page.uid,

--- a/src/pages/news/post/[uid].tsx
+++ b/src/pages/news/post/[uid].tsx
@@ -90,12 +90,12 @@ export const getStaticPaths = async () => {
   }
   const paths: Array<Path> = []
   pages.forEach((page) => {
-    paths.push({
-      params: {
-        uid: page.uid,
-      },
-      locale: 'en',
-    })
+    // paths.push({
+    //   params: {
+    //     uid: page.uid,
+    //   },
+    //   locale: 'en',
+    // })
     paths.push({
       params: {
         uid: page.uid,


### PR DESCRIPTION
## 行った変更
- nextのlocaleの設定から英語を外した
- 404エラーがユーザーに表示されないように、英語版ページに飛んでも日本語版ページにリダイレクトするように変更

## スクリーンショット
https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/92075fb1-24cd-4119-93fe-10dca5c9612e

## 関連するissue
- #297 
- #301 