### PR TITLE
英語版ページのヘッダーのナビゲーションからNewsとHubを非表示

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -47,7 +47,7 @@ const Header = () => {
       props: React.ComponentProps<'svg'> & { title?: string; titleId?: string },
     ) => JSX.Element
     isTargetBlank?: boolean
-    display?: string
+    display?: boolean
   }
 
   const resources: ReadonlyArray<Resources> = [
@@ -65,13 +65,13 @@ const Header = () => {
       name: 'ニュース',
       href: '/news/1',
       icon: NewspaperIcon,
-      display: locale === 'en' ? 'hidden' : '',
+      display: locale === 'en' ? true : false,
     },
     {
       name: 'Hub',
       href: '/hub/1',
       icon: Squares2X2Icon,
-      display: locale === 'en' ? 'hidden' : '',
+      display: locale === 'en' ? true : false,
     },
     {
       name: locale === 'ja' ? 'ブログ' : 'Blogs',
@@ -120,7 +120,7 @@ const Header = () => {
                   (isCurrentPage(resource.href)
                     ? 'border-b-2 border-gray-500 '
                     : '') +
-                  (resource.display ? `${resource.display}` : '')
+                  (resource.display ? 'hidden' : '')
                 }
               >
                 {resource.name}
@@ -180,7 +180,7 @@ const Header = () => {
                       href={resource.href}
                       className={
                         `-m-3 flex items-center rounded-lg p-3 hover:bg-gray-50 ` +
-                        (resource.display ? `${resource.display}` : '')
+                        (resource.display ? 'hidden' : '')
                       }
                       target={resource.isTargetBlank ? '_blank' : ''}
                     >

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -47,6 +47,7 @@ const Header = () => {
       props: React.ComponentProps<'svg'> & { title?: string; titleId?: string },
     ) => JSX.Element
     isTargetBlank?: boolean
+    display?: string
   }
 
   const resources: ReadonlyArray<Resources> = [
@@ -61,17 +62,19 @@ const Header = () => {
       icon: CursorArrowRaysIcon,
     },
     {
-      name: locale === 'ja' ? 'ニュース' : 'News',
+      name: 'ニュース',
       href: '/news/1',
       icon: NewspaperIcon,
+      display: locale === 'ja' ? '' : 'hidden',
     },
     {
       name: 'Hub',
       href: '/hub/1',
       icon: Squares2X2Icon,
+      display: locale === 'ja' ? '' : 'hidden',
     },
     {
-      name: 'ブログ',
+      name: locale === 'ja' ? 'ブログ' : 'Blogs',
       href: 'https://tech.anti-pattern.co.jp/',
       icon: DocumentTextIcon,
       isTargetBlank: true,
@@ -115,8 +118,9 @@ const Header = () => {
                 className={
                   'flex items-center gap-1 text-base font-medium text-gray-500 hover:text-gray-900 pb-1 ' +
                   (isCurrentPage(resource.href)
-                    ? 'border-b-2 border-gray-500'
-                    : '')
+                    ? 'border-b-2 border-gray-500 '
+                    : '') +
+                  (resource.display ? `${resource.display}` : '')
                 }
               >
                 {resource.name}
@@ -174,7 +178,10 @@ const Header = () => {
                     <Link
                       key={resource.name}
                       href={resource.href}
-                      className="-m-3 flex items-center rounded-lg p-3 hover:bg-gray-50"
+                      className={
+                        `-m-3 flex items-center rounded-lg p-3 hover:bg-gray-50 ` +
+                        (resource.display ? `${resource.display}` : '')
+                      }
                       target={resource.isTargetBlank ? '_blank' : ''}
                     >
                       <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md bg-ap-green text-white">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -65,13 +65,13 @@ const Header = () => {
       name: 'ニュース',
       href: '/news/1',
       icon: NewspaperIcon,
-      display: locale === 'ja' ? '' : 'hidden',
+      display: locale === 'en' ? 'hidden' : '',
     },
     {
       name: 'Hub',
       href: '/hub/1',
       icon: Squares2X2Icon,
-      display: locale === 'ja' ? '' : 'hidden',
+      display: locale === 'en' ? 'hidden' : '',
     },
     {
       name: locale === 'ja' ? 'ブログ' : 'Blogs',

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -47,7 +47,7 @@ const Header = () => {
       props: React.ComponentProps<'svg'> & { title?: string; titleId?: string },
     ) => JSX.Element
     isTargetBlank?: boolean
-    display?: boolean
+    isDisplayNone?: boolean
   }
 
   const resources: ReadonlyArray<Resources> = [
@@ -65,13 +65,13 @@ const Header = () => {
       name: 'ニュース',
       href: '/news/1',
       icon: NewspaperIcon,
-      display: locale === 'en' ? true : false,
+      isDisplayNone: locale === 'en' ? true : false,
     },
     {
       name: 'Hub',
       href: '/hub/1',
       icon: Squares2X2Icon,
-      display: locale === 'en' ? true : false,
+      isDisplayNone: locale === 'en' ? true : false,
     },
     {
       name: locale === 'ja' ? 'ブログ' : 'Blogs',
@@ -120,7 +120,7 @@ const Header = () => {
                   (isCurrentPage(resource.href)
                     ? 'border-b-2 border-gray-500 '
                     : '') +
-                  (resource.display ? 'hidden' : '')
+                  (resource.isDisplayNone ? 'hidden' : '')
                 }
               >
                 {resource.name}
@@ -180,7 +180,7 @@ const Header = () => {
                       href={resource.href}
                       className={
                         `-m-3 flex items-center rounded-lg p-3 hover:bg-gray-50 ` +
-                        (resource.display ? 'hidden' : '')
+                        (resource.isDisplayNone ? 'hidden' : '')
                       }
                       target={resource.isTargetBlank ? '_blank' : ''}
                     >


### PR DESCRIPTION
## 行った変更
英語版ページのナビゲーションにおいて、NewsとHubが非表示になるように変更した

## スクリーンショット
### PC画面
<img width="793" alt="スクリーンショット 2024-06-07 20 39 58" src="https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/6516e0db-f610-45be-91e3-567f4a8420d9">

### SP画面
<img width="288" alt="スクリーンショット 2024-06-07 20 40 13" src="https://github.com/Anti-Pattern-Inc/anti-pattern-inc.github.io/assets/107157836/204c79cd-7940-45ef-b89e-f20409c4e1d9">

## 関連issue
- #297 
- #304 

## 実際に確認する場合
英語版ページをlocaleの設定を変更して非表示にしているのでコメントアウト箇所を有効にしてから確認する必要があります