### PR TITLE
[AWS Marketplace掲載支援サービスサイト] 「こんな方におすすめ」内のスタイル修正

### DIFF
--- a/src/components/support-for-aws-marketplace-listing/AboutAWSMarketplace.tsx
+++ b/src/components/support-for-aws-marketplace-listing/AboutAWSMarketplace.tsx
@@ -41,13 +41,13 @@ const Recommended = () => {
         こんな方におすすめ
       </h3>
       <div className="flex max-w-5xl gap-4 md:gap-10 flex-col md:flex-row">
-        <div className="flex-1 bg-white rounded-lg flex flex-col items-center justify-between gap-4 md:gap-6 p-6">
+        <div className="flex-1 bg-white rounded-lg flex flex-col items-center gap-4 md:gap-6 p-6">
           <Image
             src={MonitoringIcon}
             alt=""
             className="w-20 md:w-[120px] h-20 md:h-[120px]"
           />
-          <p className="text-center text-sm md:text-base">
+          <p className="text-center text-sm md:text-base flex-grow content-center">
             AWS Marketplace への SaaS 製品を掲載してビジネス拡大を図りたい方
           </p>
         </div>
@@ -57,7 +57,7 @@ const Recommended = () => {
             alt=""
             className="w-20 md:w-[120px] h-20 md:h-[120px]"
           />
-          <p className="text-center text-sm md:text-base">
+          <p className="text-center text-sm md:text-base flex-grow content-center">
             クイックに掲載を実現していきたいが、AWS Marketplace
             への掲載に何が必要か深く理解していない方
           </p>
@@ -68,7 +68,7 @@ const Recommended = () => {
             alt=""
             className="w-20 md:w-[120px] h-20 md:h-[120px]"
           />
-          <p className="text-center text-sm md:text-base">
+          <p className="text-center text-sm md:text-base flex-grow content-center">
             コア機能開発に集中する必要があり、掲載のための設計や開発などにリソースを割くことが難しい方
           </p>
         </div>
@@ -86,7 +86,7 @@ const Consideration = () => {
         検討すべきこと
       </h3>
       <div className="flex flex-col gap-6 md:gap-10">
-        <p className="mx-4 max-w-5xl text-sm md:text-base ">
+        <p className="mx-4 max-w-5xl text-sm md:text-base">
           掲載にあたりインテグレーションが必要となるため、AWS Marketplace
           への理解度を高めて事業的な効果を把握し、掲載によるお客様のビジネスメリット(期待)によって、どこまで作り込むかを検討する必要があります。
         </p>


### PR DESCRIPTION
# issueへのリンク  
#349 

## やったこと(実装内容)
- デザイナーFBにて、「こんな方におすすめ」エリアのPCの見た目の修正依頼をいただいたため対応。
  - 左のブロックのテキスト（AWS Marketplace への〜）が下揃えになっているので、中央寄せな見た目に調整

## 動作確認(スクショ) 
||sp|pc|
|--|--|--|
|修正後|<img width="1440" alt="スクリーンショット 2025-02-19 7 10 14" src="https://github.com/user-attachments/assets/f789da9e-f466-40dc-b51f-c86095db711a" />|<img width="390" alt="スクリーンショット 2025-02-19 7 25 01" src="https://github.com/user-attachments/assets/649e04a1-f02e-48dc-9a6b-0d541322ff20" />|
|修正前|<img width="1440" alt="スクリーンショット 2025-02-19 7 28 31" src="https://github.com/user-attachments/assets/e316a46f-54f1-4b86-a2aa-32e648543b46" />|<img width="390" alt="スクリーンショット 2025-02-19 7 28 58" src="https://github.com/user-attachments/assets/fc1e25b7-0b13-44ff-afd6-60415dc42001" />


## 補足
`https://anti-pattern-inc-github-io-git-feature-349-anti-pattern-inc.vercel.app/services/support-for-aws-marketplace-listing` こちらで確認可能です。