### PR TITLE
[AWS Marketplace掲載支援サービスサイト] 料金プラン文言変更

### DIFF
--- a/src/components/support-for-aws-marketplace-listing/AboutSupportForAWSMarketplaceListing.tsx
+++ b/src/components/support-for-aws-marketplace-listing/AboutSupportForAWSMarketplaceListing.tsx
@@ -146,7 +146,7 @@ const Purchase = () => {
           <div className="flex flex-col justify-center items-center gap-4 py-4 md:pt-8 md:pb-10">
             <div className="text-2xl leading-8 md:text-[34px] md:leading-[42px] font-bold tracking-[0.25px]">
               180万<span className="text-base md:text-xl">(税別)</span> +
-              2ヶ月固定
+              2ヶ月程度固定
             </div>
             <div className="text-sm md:text-base">AWS Marketplace での購買</div>
           </div>


### PR DESCRIPTION
# issueへのリンク  
#352 

## やったこと(実装内容)
- 2ヶ月固定→2ヶ月程度固定に文言変更となったため、修正

## 動作確認(スクショ) 
||sp|pc|
|--|--|--|
|修正後|<img width="390" alt="スクリーンショット 2025-02-19 7 40 31" src="https://github.com/user-attachments/assets/643c130b-cb3b-4980-a2f6-bbdbe228e999" />|<img width="676" alt="スクリーンショット 2025-02-19 7 40 16" src="https://github.com/user-attachments/assets/7d3ae2c2-e5ed-4c9b-9d93-e327e73c4545" />|
|修正前|<img width="393" alt="スクリーンショット 2025-02-19 7 38 52" src="https://github.com/user-attachments/assets/90e798d3-e55b-4f04-b765-8ae8b387c1d8" />|<img width="674" alt="スクリーンショット 2025-02-19 7 38 59" src="https://github.com/user-attachments/assets/26bb53ac-de07-424d-8b23-71747ce792d0" />|

## 補足
`https://anti-pattern-inc-github-io-git-feature-352-anti-pattern-inc.vercel.app/services/support-for-aws-marketplace-listing` こちらで確認可能です。