### PR TITLE
[AWS Marketplace掲載支援サービスサイト] 文言修正

### DIFF
--- a/src/components/features/ServiceList.tsx
+++ b/src/components/features/ServiceList.tsx
@@ -45,13 +45,17 @@ const Service = ({ src, name, ja_name, description, url, isBlank }: Props) => {
               target={isBlank ? '_blank' : '_self'}
               rel="noreferrer"
             >
-              <span>SERVICE SITE</span>
-              {isBlank && (
-                <Image
-                  src={ServiceLinkIcon}
-                  alt={t.services.service_site.img_alt}
-                  className="w-3 inline mb-1 ml-1"
-                />
+              {isBlank ? (
+                <>
+                  <span>SERVICE SITE</span>
+                  <Image
+                    src={ServiceLinkIcon}
+                    alt={t.services.service_site.img_alt}
+                    className="w-3 inline mb-1 ml-1"
+                  />
+                </>
+              ) : (
+                <span>SERVICE PAGE</span>
               )}
             </a>
           </p>

--- a/src/components/support-for-aws-marketplace-listing/AboutSupportForAWSMarketplaceListing.tsx
+++ b/src/components/support-for-aws-marketplace-listing/AboutSupportForAWSMarketplaceListing.tsx
@@ -152,9 +152,13 @@ const Purchase = () => {
             ヒアリング/設計フェーズ
           </div>
           <div className="flex flex-col justify-center items-center gap-4 py-4 md:pt-8 md:pb-10">
-            <div className="text-2xl leading-8 md:text-[34px] md:leading-[42px] font-bold tracking-[0.25px]">
-              180万<span className="text-base md:text-xl">(税別)</span> +
-              2ヶ月程度固定
+            <div className="text-2xl leading-8 md:text-[34px] md:leading-[42px] text-center font-bold tracking-[0.25px]">
+              2ヶ月間で実施
+              <br />
+              180万
+              <span className="text-base md:text-xl">(税別)</span>
+              の業務委託費
+              <span className="text-base md:text-xl">(固定)</span>
             </div>
             <div className="text-sm md:text-base">AWS Marketplace での購買</div>
           </div>


### PR DESCRIPTION
# issueへのリンク  
#360 

## やったこと(実装内容)
- サービスリストのリンクについて、別サイトに飛ばない場合、「SERVICE PAGE」と表記
- 料金プラン文言を変更

https://anti-patterninc.slack.com/archives/C050U4WPW04/p1742867844145859

## 動作確認(スクショ) 
||修正前|修正後|
|--|--|--|
|サービスリスト|<img width="240" alt="スクリーンショット 2025-03-25 14 52 10" src="https://github.com/user-attachments/assets/15d48683-cfc8-475b-80b9-3927fbeb19a4" />|![スクリーンショット 2025-03-25 14 39 43](https://github.com/user-attachments/assets/003911bb-285c-462d-90d8-bf3e15b23602)|
|料金プランsp|<img width="380" alt="スクリーンショット 2025-03-25 14 53 02" src="https://github.com/user-attachments/assets/8551ecc9-4284-450d-afed-57e28d3cb078" />|<img width="377" alt="スクリーンショット 2025-03-25 14 45 41" src="https://github.com/user-attachments/assets/083b520e-150d-4caa-8922-ad7a5f831f6a" />|
|料金プランpc|<img width="1078" alt="スクリーンショット 2025-03-25 14 53 13" src="https://github.com/user-attachments/assets/764e682d-fe9f-4055-bc52-b78a7b212fed" />|<img width="1082" alt="スクリーンショット 2025-03-25 14 44 05" src="https://github.com/user-attachments/assets/29fc66b0-f397-4f23-b610-8de4f0162e59" />|

## 補足
`https://anti-pattern-inc-github-io-git-feature-360-anti-pattern-inc.vercel.app/services/support-for-aws-marketplace-listing` こちらで確認可能です。